### PR TITLE
Fix GitHub Actions backend tests path

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,12 +22,12 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '9.0.x'
-      - name: Restore dependencies # Restaura dependencias del backend
-        run: dotnet restore ./app/Bdfy/Bdfy.csproj
-      - name: Build # Compila el backend
-        run: dotnet build --no-restore ./app/Bdfy/Bdfy.csproj
+      - name: Restore dependencies # Restaura dependencias del backend y tests
+        run: dotnet restore ./app/BDfy.sln
+      - name: Build # Compila el backend y el proyecto de pruebas
+        run: dotnet build --no-restore ./app/BDfy.sln
       - name: Test # Ejecuta los tests del backend
-        run: dotnet test --no-build --verbosity normal ./app/Bdfy/Bdfy.csproj
+        run: dotnet test --no-build --verbosity normal ./app/Bdfy.Tests/Bdfy.Tests.csproj
 
   frontend:
     name: Build & Test React Frontend

--- a/app/Bdfy.Tests/Services/AutoBidServiceTests.cs
+++ b/app/Bdfy.Tests/Services/AutoBidServiceTests.cs
@@ -2,6 +2,7 @@ using BDfy.Services;
 using BDfy.Data;
 using BDfy.Models;
 using BDfy.Hub;
+using BDfy.Dtos;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;


### PR DESCRIPTION
## Summary
- restore and build solution so that the test project is included
- run Bdfy.Tests explicitly in CI
- include DTO namespaces in AutoBidServiceTests

## Testing
- `npm test -- --watchAll=false` *(fails: Missing script)*
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865e199db4883238df9a3ee5f59f9cf